### PR TITLE
fixed typo for in lesson_3

### DIFF
--- a/lesson_3/index.html
+++ b/lesson_3/index.html
@@ -6,7 +6,7 @@
   </head>
 
   <body>
-    <h1>Add color to graphics using HTML Canvas</h1>
+    <h1>Specifying height and width of your base canvas element</h1>
     <canvas id="canvas"></canvas>
 
     <script src="script.js"></script>


### PR DESCRIPTION
Looks like the HTML header was labeled for lesson 2 in the lesson 3 folder
![](https://d3vv6lp55qjaqc.cloudfront.net/items/3g1P103e3K3A0233431l/Image%202017-04-20%20at%2010.22.39%20AM.png?v=c880c095)